### PR TITLE
Add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.8",
-        "laravel/framework": "^9.46|^10.10|^11.0"
+        "laravel/framework": "^9.46|^10.10|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",


### PR DESCRIPTION
### Summary

Add Laravel 12 compatibility to `composer.json`

This patch adds `^12.0` to the Laravel version constraint, alongside the existing constraints. This allows installation in Laravel 12+ projects while continuing to support previous major versions. No code changes were required.